### PR TITLE
Oauth redirects

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/HackIllinois/api-auth/config"
 	"github.com/HackIllinois/api-auth/models"
 	"github.com/HackIllinois/api-auth/service"
 	"github.com/HackIllinois/api-commons/errors"
@@ -27,7 +28,13 @@ func SetupController(route *mux.Route) {
 func Authorize(w http.ResponseWriter, r *http.Request) {
 	provider := mux.Vars(r)["provider"]
 
-	redirect_url, err := service.GetAuthorizeRedirect(provider)
+	redirect_uri := r.URL.Query().Get("redirect_uri")
+
+	if redirect_uri == "" {
+		redirect_uri = config.AUTH_REDIRECT_URI
+	}
+
+	redirect_url, err := service.GetAuthorizeRedirect(provider, redirect_uri)
 
 	if err != nil {
 		panic(errors.UnprocessableError(err.Error()))
@@ -46,7 +53,13 @@ func Login(w http.ResponseWriter, r *http.Request) {
 
 	provider := mux.Vars(r)["provider"]
 
-	oauth_token, err := service.GetOauthToken(oauth_code.Code, provider)
+	redirect_uri := r.URL.Query().Get("redirect_uri")
+
+	if redirect_uri == "" {
+		redirect_uri = config.AUTH_REDIRECT_URI
+	}
+
+	oauth_token, err := service.GetOauthToken(oauth_code.Code, provider, redirect_uri)
 
 	if err != nil {
 		panic(errors.UnprocessableError(err.Error()))

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -1,19 +1,23 @@
 Authorization
 =============
 
-GET /auth/PROVIDER/
-----------------------------
+GET /auth/PROVIDER/?redirect_uri=AUTHREDIRECTURI
+------------------------------------------------
 
 Redirects to the `PROVIDER`'s oauth authorization page. Once the user accepts the oauth authorization they will be redirected to the client's auth page with an oauth code. This code should be sent to the api to be exchanged for an api jwt.
 
-Valid `PROVIDER` strings: `github`
+Valid `PROVIDER` strings: `github`, `google`
 
-POST /auth/code/PROVIDER/
-----------------------------------
+`AUTHREDIRECTURI` can be specified to override the default oauth redirect uri.
+
+POST /auth/code/PROVIDER/?redirect_uri=AUTHREDIRECTURI
+------------------------------------------------------
 
 Exchanges a valid oauth code from a jwt from the api. This jwt should be placed in the `Authorization` header for all future api requests.
 
-Valid `PROVIDER` strings: `github`
+Valid `PROVIDER` strings: `github`, `google`
+
+`AUTHREDIRECTURI` can be specified to override the default oauth redirect uri.
 
 Request format:
 ```

--- a/service/google_service.go
+++ b/service/google_service.go
@@ -36,13 +36,13 @@ func GetGoogleEmail(oauth_token string) (string, error) {
 /*
 	Uses a valid oauth code to get a valid oauth token for the user
 */
-func GetGoogleOauthToken(code string) (string, error) {
+func GetGoogleOauthToken(code string, redirect_uri string) (string, error) {
 	request, err := grequests.Post("https://www.googleapis.com/oauth2/v4/token", &grequests.RequestOptions{
 		Params: map[string]string{
 			"client_id":     config.GOOGLE_CLIENT_ID,
 			"client_secret": config.GOOGLE_CLIENT_SECRET,
 			"code":          code,
-			"redirect_uri":  config.AUTH_REDIRECT_URI,
+			"redirect_uri":  redirect_uri,
 			"grant_type":    "authorization_code",
 		},
 		Headers: map[string]string{

--- a/service/oauth_service.go
+++ b/service/oauth_service.go
@@ -9,12 +9,12 @@ import (
 /*
 	Return the oauth authoization url for the given provider
 */
-func GetAuthorizeRedirect(provider string) (string, error) {
+func GetAuthorizeRedirect(provider string, redirect_uri string) (string, error) {
 	switch provider {
 	case "github":
-		return "https://github.com/login/oauth/authorize?client_id=" + config.GITHUB_CLIENT_ID, nil
+		return "https://github.com/login/oauth/authorize?client_id=" + config.GITHUB_CLIENT_ID + "&redirect_uri=" + redirect_uri, nil
 	case "google":
-		return "https://accounts.google.com/o/oauth2/v2/auth?client_id=" + config.GOOGLE_CLIENT_ID + "&redirect_uri=" + config.AUTH_REDIRECT_URI + "&scope=profile%20email&response_type=code", nil
+		return "https://accounts.google.com/o/oauth2/v2/auth?client_id=" + config.GOOGLE_CLIENT_ID + "&redirect_uri=" + redirect_uri + "&scope=profile%20email&response_type=code", nil
 	default:
 		return "", errors.New("Invalid provider")
 	}
@@ -37,12 +37,12 @@ func GetEmail(oauth_token string, provider string) (string, error) {
 /*
 	Converts an oauth code to an oauth token for the specified provider
 */
-func GetOauthToken(code string, provider string) (string, error) {
+func GetOauthToken(code string, provider string, redirect_uri string) (string, error) {
 	switch provider {
 	case "github":
 		return GetGithubOauthToken(code)
 	case "google":
-		return GetGoogleOauthToken(code)
+		return GetGoogleOauthToken(code, redirect_uri)
 	default:
 		return "", errors.New("Invalid provider")
 	}


### PR DESCRIPTION
Addresses #33 

- [x] Allow users to specify redirect uri when authenticating with oauth provider
    - [x] User can specify uri on `GET /{provider}/?redirect_uri=<URI_HERE>`
    - [x] User can specify uri on `POST /code/{provider}/?redirect_uri=<URI_HERE>`
        - Google requires the uri on this endpoint be the same as the original uri
        - GitHub does not require a uri for this endpoint

If no `redirect_uri` is specified the config specified `AUTH_REDIRECT_URI` will be used.